### PR TITLE
Added minimal python package structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+robocluster.egg-info
+__pycache__

--- a/robocluster/__init__.py
+++ b/robocluster/__init__.py
@@ -1,0 +1,2 @@
+def request(uri):
+    raise NotImplementedError()

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,15 @@
 from setuptools import setup
 
 setup(name='robocluster',
-      version='0.01',
+      version='0.1',
       description='Distributed robotics framework',
       url='https://github.com/UofSSpaceTeam/robocluster',
       author='UofSSpaceTeam',
       author_email='software@usst.ca',
       license='ECL-2.0',
       packages=['robocluster'],
+      install_requires=[
+          'pyzmq',
+      ],
       zip_safe=False)
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(name='robocluster',
+      version='0.01',
+      description='Distributed robotics framework',
+      url='https://github.com/UofSSpaceTeam/robocluster',
+      author='UofSSpaceTeam',
+      author_email='software@usst.ca',
+      license='ECL-2.0',
+      packages=['robocluster'],
+      zip_safe=False)
+


### PR DESCRIPTION
From the top directory, you can install robocluster with
```
pip install -e .
```
You can then import robocluster in all you python projects. The `-e` flag sets things up so that changes to the source code will be seen without having to reinstall the package constantly.