### PR TITLE
WIP: Try to fix windows compatability issue

### DIFF
--- a/robocluster/net.py
+++ b/robocluster/net.py
@@ -61,7 +61,12 @@ class Socket:
                 mreq
             )
         self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self._socket.bind(self._address)
+
+        ip, port = self._address
+        if self.is_multicast:
+            ip = ''
+        self._socket.bind((ip, port))
+
         self._bound = True
 
     def send(self, data, address=None):


### PR DESCRIPTION
Windows does not allow binding to a specific address for multicast
networking, so we bind to all addresses on that port instead.
