### PR TITLE
Serial device

### DIFF
--- a/examples/independantSerial.py
+++ b/examples/independantSerial.py
@@ -1,9 +1,11 @@
-# Alternative method of serial device creation
+'''Alternate way to instantiate serial devices manually'''
+
 from robocluster import SerialDevice
 import asyncio
 sDevice = SerialDevice('/dev/ttyACM0')
 
 async def serial_test():
+    '''Write a value to the device and read the response'''
     async with sDevice as ser:
         while True:
             print("writing...")

--- a/examples/independantSerial.py
+++ b/examples/independantSerial.py
@@ -1,0 +1,16 @@
+# Alternative method of serial device creation
+from robocluster import SerialDevice
+import asyncio
+sDevice = SerialDevice('/dev/ttyACM0')
+
+async def serial_test():
+    async with sDevice as ser:
+        while True:
+            print("writing...")
+            await ser.write_packet("T")
+            msg = await ser.read_packet()
+            print(msg)
+
+loop = asyncio.get_event_loop()
+loop.create_task(serial_test())
+loop.run_forever()

--- a/examples/serial_test.py
+++ b/examples/serial_test.py
@@ -2,38 +2,11 @@ from robocluster import Device
 
 
 device = Device('link', 'rover')
-# sDevice = device.create_serial('/dev/ttyACM0')
-#
-# @sDevice.on('test')
-# async def callback(event, data):
-#     print(event, data)
-#
-# device.run()
+sDevice = device.create_serial('/dev/ttyACM0')
 
-# Alternative method of serial device creation
-from robocluster import SerialDevice
-import asyncio
-sDevice = SerialDevice('/dev/ttyACM0', loop=device._loop)
-# device.link_serial(sDevice)
 
-async def serial_read():
-    async with sDevice as ser:
-        while True:
-            print('reading')
-            msg = await ser.read_packet()
-            print(msg)
+@sDevice.on('test')
+async def callback(event, data):
+    print(event, data)
 
-@device.task
-async def serial_write():
-    async with sDevice as ser:
-        while True:
-            print('writing')
-            await ser.write_packet("T")
-            msg = await ser.read_packet()
-            print(msg)
-
-# loop = asyncio.get_event_loop()
-# loop.create_task(serial_read())
-# loop.create_task(serial_write())
-# loop.run_forever();
 device.run()

--- a/examples/serial_test.py
+++ b/examples/serial_test.py
@@ -1,16 +1,28 @@
-from robocluster.serial import SerialDevice
-import asyncio
+from robocluster import Device
 
 
-device  = SerialDevice('/dev/ttyACM0')
+device = Device('link', 'rover')
+device.create_serial('/dev/ttyACM0')
 
-async def read_data():
-    while not device.isInitialized():
-        asyncio.sleep(0.01)
 
-    msg = await device.read_packet()
-    print(msg)
+@device.on('test')
+async def callback(event, data):
+    print(event, data)
 
-loop = asyncio.get_event_loop()
+device.run()
 
-loop.run_until_complete(read_data())
+# Alternative method of serial device creation
+# from robocluster import SerialDevice
+# import asyncio
+# sDevice = SerialDevice('/dev/ttyACM0')
+# device.link_serial(sDevice)
+
+# async def serial_read():
+#     while not sDevice.isInitialized():
+#         asyncio.sleep(0.01)
+#     while True:
+#         msg = await sDevice.read_packet()
+#         print(msg)
+
+# loop = asyncio.get_event_loop()
+# loop.run_until_complete(serial_read())

--- a/examples/serial_test.py
+++ b/examples/serial_test.py
@@ -2,10 +2,9 @@ from robocluster import Device
 
 
 device = Device('link', 'rover')
-device.create_serial('/dev/ttyACM0')
+sDevice = device.create_serial('/dev/ttyACM0')
 
-
-@device.on('test')
+@sDevice.on('test')
 async def callback(event, data):
     print(event, data)
 
@@ -14,7 +13,6 @@ device.run()
 # Alternative method of serial device creation
 # from robocluster import SerialDevice
 # import asyncio
-# sDevice = SerialDevice('/dev/ttyACM0')
 # device.link_serial(sDevice)
 
 # async def serial_read():

--- a/examples/serial_test.py
+++ b/examples/serial_test.py
@@ -1,0 +1,16 @@
+from robocluster.serial import SerialDevice
+import asyncio
+
+
+device  = SerialDevice('/dev/ttyACM0')
+
+async def read_data():
+    while not device.isInitialized():
+        asyncio.sleep(0.01)
+
+    msg = await device.read_packet()
+    print(msg)
+
+loop = asyncio.get_event_loop()
+
+loop.run_until_complete(read_data())

--- a/examples/serial_test.py
+++ b/examples/serial_test.py
@@ -1,5 +1,8 @@
-from robocluster import Device
+'''Barebones example of how to register a
+callback for events sent by the serial device.
+'''
 
+from robocluster import Device
 
 device = Device('link', 'rover')
 sDevice = device.create_serial('/dev/ttyACM0')
@@ -7,6 +10,7 @@ sDevice = device.create_serial('/dev/ttyACM0')
 
 @sDevice.on('test')
 async def callback(event, data):
+    '''Print the event and value'''
     print(event, data)
 
 device.run()

--- a/examples/serial_test.py
+++ b/examples/serial_test.py
@@ -13,14 +13,14 @@ device.run()
 # Alternative method of serial device creation
 # from robocluster import SerialDevice
 # import asyncio
+# sDevice = SerialDevice('/dev/ttyACM0')
 # device.link_serial(sDevice)
 
 # async def serial_read():
-#     while not sDevice.isInitialized():
-#         asyncio.sleep(0.01)
-#     while True:
-#         msg = await sDevice.read_packet()
-#         print(msg)
-
+#     async with sDevice as ser:
+#         while True:
+#             msg = await ser.read_packet()
+#             print(msg)
+#
 # loop = asyncio.get_event_loop()
 # loop.run_until_complete(serial_read())

--- a/examples/serial_test.py
+++ b/examples/serial_test.py
@@ -2,25 +2,38 @@ from robocluster import Device
 
 
 device = Device('link', 'rover')
-sDevice = device.create_serial('/dev/ttyACM0')
-
-@sDevice.on('test')
-async def callback(event, data):
-    print(event, data)
-
-device.run()
+# sDevice = device.create_serial('/dev/ttyACM0')
+#
+# @sDevice.on('test')
+# async def callback(event, data):
+#     print(event, data)
+#
+# device.run()
 
 # Alternative method of serial device creation
-# from robocluster import SerialDevice
-# import asyncio
-# sDevice = SerialDevice('/dev/ttyACM0')
+from robocluster import SerialDevice
+import asyncio
+sDevice = SerialDevice('/dev/ttyACM0', loop=device._loop)
 # device.link_serial(sDevice)
 
-# async def serial_read():
-#     async with sDevice as ser:
-#         while True:
-#             msg = await ser.read_packet()
-#             print(msg)
-#
+async def serial_read():
+    async with sDevice as ser:
+        while True:
+            print('reading')
+            msg = await ser.read_packet()
+            print(msg)
+
+@device.task
+async def serial_write():
+    async with sDevice as ser:
+        while True:
+            print('writing')
+            await ser.write_packet("T")
+            msg = await ser.read_packet()
+            print(msg)
+
 # loop = asyncio.get_event_loop()
-# loop.run_until_complete(serial_read())
+# loop.create_task(serial_read())
+# loop.create_task(serial_write())
+# loop.run_forever();
+device.run()

--- a/examples/two_serial.py
+++ b/examples/two_serial.py
@@ -1,3 +1,7 @@
+'''Demonstration of registering two serial
+devices with one Device event loop
+'''
+
 from robocluster import Device
 
 device = Device('link', 'rover')
@@ -8,10 +12,12 @@ print(teensy)
 
 @micro.on('micro')
 async def callback(event, data):
+    '''Callback for serial device 1'''
     print(event, data)
 
 @teensy.on('teensy')
 async def callback(event, data):
+    '''Callback for serial device 2'''
     print(event, data)
 
 device.run()

--- a/examples/two_serial.py
+++ b/examples/two_serial.py
@@ -1,0 +1,17 @@
+from robocluster import Device
+
+device = Device('link', 'rover')
+micro = device.create_serial('/dev/ttyACM0')
+teensy = device.create_serial('/dev/ttyACM1')
+print(micro)
+print(teensy)
+
+@micro.on('micro')
+async def callback(event, data):
+    print(event, data)
+
+@teensy.on('teensy')
+async def callback(event, data):
+    print(event, data)
+
+device.run()

--- a/examples/two_serial.py
+++ b/examples/two_serial.py
@@ -11,12 +11,12 @@ print(micro)
 print(teensy)
 
 @micro.on('micro')
-async def callback(event, data):
+async def micro_callback(event, data):
     '''Callback for serial device 1'''
     print(event, data)
 
 @teensy.on('teensy')
-async def callback(event, data):
+async def teensy_callback(event, data):
     '''Callback for serial device 2'''
     print(event, data)
 

--- a/examples/vesc_test.py
+++ b/examples/vesc_test.py
@@ -6,7 +6,7 @@ from pyvesc import BlinkLed
 
 
 device = Device('link', 'rover')
-serial = device.create_serial('/dev/ttyACM0', pktformat='vesc')
+serial = device.create_serial('/dev/ttyACM0', encoding='vesc')
 
 blink_val = 0
 

--- a/examples/vesc_test.py
+++ b/examples/vesc_test.py
@@ -1,0 +1,21 @@
+from robocluster import Device
+from pyvesc import BlinkLed
+
+
+device = Device('link', 'rover')
+sDevice = device.create_serial('/dev/ttyACM0', pktformat='vesc')
+
+blink_val = 0
+
+@sDevice.on('test')
+async def callback(event, data):
+    print(event, data)
+
+@sDevice.on('ExampleSendMessage')
+async def callback(event, data):
+    global blink_val
+    print(data.string)
+    await sDevice.write_packet(BlinkLed(blink_val))
+    blink_val = not blink_val
+
+device.run()

--- a/examples/vesc_test.py
+++ b/examples/vesc_test.py
@@ -1,3 +1,6 @@
+'''Demonstration of interacting with
+a VESC device.
+'''
 from robocluster import Device
 from pyvesc import BlinkLed
 
@@ -7,12 +10,9 @@ sDevice = device.create_serial('/dev/ttyACM0', pktformat='vesc')
 
 blink_val = 0
 
-@sDevice.on('test')
-async def callback(event, data):
-    print(event, data)
-
 @sDevice.on('ExampleSendMessage')
 async def callback(event, data):
+    '''Print string that was sent and toggle LED'''
     global blink_val
     print(data.string)
     await sDevice.write_packet(BlinkLed(blink_val))

--- a/examples/vesc_test.py
+++ b/examples/vesc_test.py
@@ -6,16 +6,16 @@ from pyvesc import BlinkLed
 
 
 device = Device('link', 'rover')
-sDevice = device.create_serial('/dev/ttyACM0', pktformat='vesc')
+serial = device.create_serial('/dev/ttyACM0', pktformat='vesc')
 
 blink_val = 0
 
-@sDevice.on('ExampleSendMessage')
+@serial.on('ExampleSendMessage')
 async def callback(event, data):
     '''Print string that was sent and toggle LED'''
     global blink_val
     print(data.string)
-    await sDevice.write_packet(BlinkLed(blink_val))
+    await serial.write_packet(BlinkLed(blink_val))
     blink_val = not blink_val
 
 device.run()

--- a/robocluster/__init__.py
+++ b/robocluster/__init__.py
@@ -1,1 +1,2 @@
 from .device import Device
+from .serial import SerialDevice

--- a/robocluster/device.py
+++ b/robocluster/device.py
@@ -113,9 +113,10 @@ class Device:
         self._serial_device[serialdevice._usbpath] = serialdevice
         self._serial_device[serialdevice._usbpath]._loop = self._loop
 
-    def create_serial(self, usbpath):
+    def create_serial(self, usbpath, pktformat='json'):
         """Create a new SerialDevice that is integrated with the callback system"""
-        self._serial_device[usbpath] = SerialDevice(usbpath, loop=self._loop)
+        self._serial_device[usbpath] = SerialDevice(
+                usbpath, pktformat=pktformat, loop=self._loop)
         return self._serial_device[usbpath]
 
     def start(self):

--- a/robocluster/device.py
+++ b/robocluster/device.py
@@ -116,7 +116,7 @@ class Device:
     def create_serial(self, usbpath):
         """Create a new SerialDevice that is integrated with the callback system"""
         self._serial_device[usbpath] = SerialDevice(usbpath, loop=self._loop)
-        return self._serial_device
+        return self._serial_device[usbpath]
 
     def start(self):
         """Start device."""
@@ -132,7 +132,7 @@ class Device:
 
         loop.create_task(self._send_task())
         loop.create_task(self._receive_task())
-        for serialdevice in self._serial_device:
+        for serialdevice in self._serial_device.values():
             self._loop.create_task(self._serial_read_task(serialdevice))
         loop.run_forever()
 

--- a/robocluster/device.py
+++ b/robocluster/device.py
@@ -134,7 +134,7 @@ class Device:
         self._serial_device = serialdevice
         self._serial_device._loop = self._loop
         # Reinitialize the connection with the new event loop
-        self._loop.create_task(self._serial_device.init_serial())
+        self._loop.call_soon_threadsafe(self._serial_device.init_serial())
 
     def create_serial(self, usbpath):
         """Create a new SerialDevice that is integrated with the callback system"""

--- a/robocluster/serial.py
+++ b/robocluster/serial.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from collections import defaultdict
 
+import pyvesc
 import serial_asyncio
 
 from .util import as_coroutine
@@ -115,7 +116,6 @@ class SerialDevice:
         elif self._encoding == 'json':
             return self._writer.write(json.dumps(data_object).encode())
         elif self._encoding == 'vesc':
-            import pyvesc
             return self._writer.write(pyvesc.encode(data_object))
         raise RuntimeError('Packet format type not supported')
 

--- a/robocluster/serial.py
+++ b/robocluster/serial.py
@@ -22,15 +22,17 @@ class SerialDevice:
         self._usbpath = usbpath
         self._baudrate = baudrate
         self.events = defaultdict(list)
-        self._loop.create_task(self.init_serial())
 
-
-    async def init_serial(self):
-        """Initialize the StreamReader and StreamWriter."""
+    async def __aenter__(self):
+        """Enter context manager and initialize the StreamReader and StreamWriter."""
         self._reader, self._writer = await serial_asyncio.open_serial_connection(
                 loop=self._loop,
                 url=self._usbpath,
                 baudrate=self._baudrate)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
 
     def isInitialized(self):
         """Checks if the StreamReader and StreamWriter are initialized"""

--- a/robocluster/serial.py
+++ b/robocluster/serial.py
@@ -11,13 +11,13 @@ class SerialDevice:
     with the robocluster network.
     """
 
-    def __init__(self, usbpath, pktformat='json', loop=None):
+    def __init__(self, usbpath, baudrate=BAUDRATE, pktformat='json', loop=None):
         self._loop = loop if loop else asyncio.get_event_loop()
         self._format = pktformat
         self._reader = None  # once initialized, an asyncio.StreamReader
         self._writer = None  # once initialized, an asyncio.StreamWriter
         self._usbpath = usbpath
-        self._baudrate = BAUDRATE
+        self._baudrate = baudrate
         self._loop.create_task(self.init_serial())
 
 
@@ -31,12 +31,11 @@ class SerialDevice:
         """Checks if the StreamReader and StreamWriter are initialized"""
         return self._reader and self._writer
 
-    async def read_byte(self):
+    def read_byte(self):
         """Read a single byte from the serial device"""
         if not self._reader:
             raise RuntimeError("Serial reader not initialized yet")
-        b = await self._reader.read(1)
-        return b
+        return self._reader.read(1)
 
     async def read_packet(self):
         """

--- a/robocluster/serial.py
+++ b/robocluster/serial.py
@@ -1,3 +1,4 @@
+'''Handles comunication to serial devices'''
 import serial_asyncio
 import asyncio
 import json

--- a/robocluster/serial.py
+++ b/robocluster/serial.py
@@ -1,0 +1,39 @@
+import serial_asyncio
+import asyncio
+import json
+
+BAUDRATE = 115200
+
+
+class SerialDevice:
+
+    def __init__(self, usbpath, pktformat='json', loop=None):
+        self._loop = loop if loop else asyncio.get_event_loop()
+        self._format = pktformat
+        self._reader = None  # once initialized, an asyncio.StreamReader
+        self._writer = None  # once initialized, an asyncio.StreamWriter
+        self._loop.create_task(self._get_serial(usbpath, BAUDRATE))
+
+
+    async def _get_serial(self, usbpath, baudrate):
+        self._reader, self._writer = await serial_asyncio.open_serial_connection(
+                url=usbpath,
+                baudrate=baudrate)
+
+    def isInitialized(self):
+        return self._reader is not None and self._writer is not None
+
+    async def read_byte(self):
+        if self._reader is None:
+            raise RuntimeError("Serial reader not initialized yet")
+        b = await self._reader.read(1)
+        return b
+
+    async def read_packet(self):
+        if self._reader is None:
+            raise RuntimeError("Serial reader not initialized yet")
+        if self._format == 'json':
+            pkt = await self._reader.readuntil(b'}')
+            return json.loads(pkt)
+
+        raise RuntimeError('Packet format type not supported')

--- a/robocluster/serial.py
+++ b/robocluster/serial.py
@@ -23,6 +23,12 @@ class SerialDevice:
         self._baudrate = baudrate
         self.events = defaultdict(list)
 
+    def __str__(self):
+        """String representation of a SerialDevice"""
+        return 'SerialDevice(usbpath={}, baudrate={}, pktformat={})'.format(
+                self._usbpath, self._baudrate, self._format
+                )
+
     async def __aenter__(self):
         """Enter context manager and initialize the StreamReader and StreamWriter."""
         self._reader, self._writer = await serial_asyncio.open_serial_connection(

--- a/robocluster/serial.py
+++ b/robocluster/serial.py
@@ -71,6 +71,18 @@ class SerialDevice:
 
         raise RuntimeError('Packet format type not supported')
 
+    async def write_packet(self, data_object):
+        """Write a packet (or bytes) to the serial device"""
+        if not self._writer:
+            raise RuntimeError("Serial writer not initialized yet")
+        if self._format == 'raw':
+            return self._writer.write(data_object)
+        elif self._format == 'utf8':
+            return self._writer.write(data_object.encode())
+        elif self._format == 'json':
+            return self._writer.write(json.dumps(data_object).encode())
+        raise RuntimeError('Packet format type not supported')
+
     def on(self, event):
         """Add a callback for an event."""
         def _decorator(callback):

--- a/robocluster/serial.py
+++ b/robocluster/serial.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 from collections import defaultdict
 
-import pyvesc
 import serial_asyncio
 
 from .util import as_coroutine

--- a/robocluster/serial.py
+++ b/robocluster/serial.py
@@ -6,31 +6,45 @@ BAUDRATE = 115200
 
 
 class SerialDevice:
+    """
+    A serial device that can optionally be integrated
+    with the robocluster network.
+    """
 
     def __init__(self, usbpath, pktformat='json', loop=None):
         self._loop = loop if loop else asyncio.get_event_loop()
         self._format = pktformat
         self._reader = None  # once initialized, an asyncio.StreamReader
         self._writer = None  # once initialized, an asyncio.StreamWriter
-        self._loop.create_task(self._get_serial(usbpath, BAUDRATE))
+        self._usbpath = usbpath
+        self._baudrate = BAUDRATE
+        self._loop.create_task(self.init_serial())
 
 
-    async def _get_serial(self, usbpath, baudrate):
+    async def init_serial(self):
+        """Initialize the StreamReader and StreamWriter."""
         self._reader, self._writer = await serial_asyncio.open_serial_connection(
-                url=usbpath,
-                baudrate=baudrate)
+                url=self._usbpath,
+                baudrate=self._baudrate)
 
     def isInitialized(self):
-        return self._reader is not None and self._writer is not None
+        """Checks if the StreamReader and StreamWriter are initialized"""
+        return self._reader and self._writer
 
     async def read_byte(self):
-        if self._reader is None:
+        """Read a single byte from the serial device"""
+        if not self._reader:
             raise RuntimeError("Serial reader not initialized yet")
         b = await self._reader.read(1)
         return b
 
     async def read_packet(self):
-        if self._reader is None:
+        """
+        Read a json packet from the serial device.
+        Assumes the packet is a single dictionary and there
+        are no nested dictionaries.
+        """
+        if not self._reader:
             raise RuntimeError("Serial reader not initialized yet")
         if self._format == 'json':
             pkt = await self._reader.readuntil(b'}')

--- a/robocluster/util.py
+++ b/robocluster/util.py
@@ -1,6 +1,24 @@
 """Utility functions for robocluster."""
 
 import re
+from functools import wraps
+from inspect import iscoroutinefunction
+
+def as_coroutine(func):
+    """
+    Convert a function to a coroutine that can be awaited.
+
+    Notes:
+    If the function is already a coroutine, it is returned directly.
+
+    """
+    @wraps(func)
+    async def _wrapper(*args, **kwargs):
+        func(*args, *kwargs)
+
+    if iscoroutinefunction(func):
+        return func
+    return _wrapper
 
 
 def duration_to_seconds(duration):

--- a/robocluster/util.py
+++ b/robocluster/util.py
@@ -4,6 +4,7 @@ import re
 from functools import wraps
 from inspect import iscoroutinefunction
 
+
 def as_coroutine(func):
     """
     Convert a function to a coroutine that can be awaited.

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(name='robocluster',
       author_email='software@usst.ca',
       license='ECL-2.0',
       packages=['robocluster'],
-      install_requires=[],
+      install_requires=['pyserial-asyncio'],
       zip_safe=False)
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,13 @@ setup(name='robocluster',
       author_email='software@usst.ca',
       license='ECL-2.0',
       packages=['robocluster'],
-      install_requires=['pyserial-asyncio'],
-      zip_safe=False)
+      install_requires=[
+            'pyserial-asyncio',
+            'pyvesc'
+      ],
+      dependency_links=[
+            'https://github.com/UofSSpaceTeam/PyVESC.git'
+      ],
+      zip_safe=False,
+)
 


### PR DESCRIPTION
Primarily for using USB serial devices with the asyncio event loop. Utilizes the [pyserial-asyncio](https://github.com/pyserial/pyserial-asyncio) library.

- [X] Open a serial connection independant from or integrated with a robocluster Device.
- [X] Read bytes from the SerialDevice
- [X] Read json packets from the SerialDevice
- [X] Json packets read from SerialDevice can trigger Device callbacks
- [x] Write bytes to the SerialDevice
- [ ] Json packets sent from Device can trigger callbacks on the MCU (not part of the python robocluster implementation)
- [ ] Autodiscovery of SerialDevices.
- [x] Support VESC communication for motor controllers
- [ ] Option to pass packets from SerialDevice through the socket api, and vice versa.
- [x] Multiple serial device support
- [ ] Hot-pluggable USB?