### PR TITLE
Changed @parameter to @property in serial.py

### DIFF
--- a/robocluster/serial.py
+++ b/robocluster/serial.py
@@ -47,12 +47,12 @@ class SerialDevice:
         """Exit async context manager."""
         pass
 
-    @parameter
+    @property
     def usb_path(self):
         """Path to the usb device."""
         return self._usb_path
 
-    @parameter
+    @property
     def initialized(self):
         """Return if the StreamReader and StreamWriter are initialized."""
         return self._reader and self._writer


### PR DESCRIPTION
The SerialDevice used a decorator that was not defined. I assume `@property` was meant instead of `@parameter`.