### PR TITLE
Device storage

### DIFF
--- a/examples/device.py
+++ b/examples/device.py
@@ -14,11 +14,12 @@ def echo(event, data):
     print(event, data)
 
 device_b = Device('device-b', group)
+device_b['message'] = 'Hello World {}!'
 
 @device_b.task
 async def hello_b():
     counter = count()
-    message = 'Hello World {}!'
+    message = device_b['message']
     while True:
         await device_b.publish('hello', message.format(next(counter)))
         await device_b.sleep(1)

--- a/examples/device.py
+++ b/examples/device.py
@@ -14,12 +14,12 @@ def echo(event, data):
     print(event, data)
 
 device_b = Device('device-b', group)
-device_b['message'] = 'Hello World {}!'
+device_b.storage.message = 'Hello World {}!'
 
 @device_b.task
 async def hello_b():
     counter = count()
-    message = device_b['message']
+    message = device_b.storage.message
     while True:
         await device_b.publish('hello', message.format(next(counter)))
         await device_b.sleep(1)

--- a/robocluster/device.py
+++ b/robocluster/device.py
@@ -46,9 +46,11 @@ class Device:
         self._storage = {}
 
     def __setitem__(self, key, value):
+        """ Allows you to store values with `device['key'] = value` """
         self._storage[key] = value
 
     def __getitem__(self, key):
+        """ Allows you to retrieve values with `value = device['key']` """
         return self._storage[key]
 
     def publish(self, topic, data):

--- a/robocluster/device.py
+++ b/robocluster/device.py
@@ -43,6 +43,14 @@ class Device:
 
         self._serial_devices = {}
 
+        self._storage = {}
+
+    def __setitem__(self, key, value):
+        self._storage[key] = value
+
+    def __getitem__(self, key):
+        return self._storage[key]
+
     def publish(self, topic, data):
         """Publish to topic."""
         packet = {

--- a/robocluster/device.py
+++ b/robocluster/device.py
@@ -11,6 +11,19 @@ from .net import Socket, key_to_multicast
 from .util import duration_to_seconds, as_coroutine
 from .serial import SerialDevice
 
+class AttributeDict(dict):
+    """
+    A dictionary that allows you to acces entries like
+    you would attributes in an object.
+    """
+    def __getattr__(self, name):
+        return self[name]
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+    def __delattr__(self, name):
+        del self[name]
 
 class Device:
     """A device to interact with the robocluster network."""
@@ -43,15 +56,12 @@ class Device:
 
         self._serial_devices = {}
 
-        self._storage = {}
+        self.__storage = AttributeDict()
 
-    def __setitem__(self, key, value):
-        """ Allows you to store values with `device['key'] = value` """
-        self._storage[key] = value
-
-    def __getitem__(self, key):
-        """ Allows you to retrieve values with `value = device['key']` """
-        return self._storage[key]
+    @property
+    def storage(self):
+        """Local device storage"""
+        return self.__storage
 
     def publish(self, topic, data):
         """Publish to topic."""


### PR DESCRIPTION
Allows Devices to be used like dictionaries, allowing you to store state information inside them:
``` python
device = Device(...)
device['thing1'] = 'Hello world'
device['thing2'] = 42

print(device['thing1'])
print(device['thing2'])
```

I found out that it is also quite easy to implement the following syntax with `__setattr__` and `__getattr__`:
``` python
device.thing1 = 'Hello'
device.thing2 = 42

print(device.thing1, device.thing2)
```

Any opinions on which is more desireable? Main problem with the latter attribute method is that it also applies to access internal to the class (self._internal_variable = ...), where as the former item method is separate from regular attribute access methods. I think the latter attribute method is easier to use, but opens the possibility for name collisions, though if all internal variables start with an underscore, it shouldn't be a problem.
I might switch to the attribute method in that case.