### PR TITLE
Added requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-pyserial
-pyserial-asyncio
-pyvesc
+# Read the setup.py for install dependencies
+.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyserial
+pyserial-asyncio
+pyvesc


### PR DESCRIPTION
Adds a requirements.txt file for use with `pip install -r requirements.txt`.
Fixes the issues with RTD documentation builds.